### PR TITLE
chore: update goreleaser syntax

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,7 +42,7 @@ changelog:
 brews:
   -
     name: decanter
-    tap:
+    repository:
       owner: p5quared
       name: homebrew-decanter
 


### PR DESCRIPTION
https://goreleaser.com/deprecations/#brewstap

## Summary by Sourcery

Chores:
- Update goreleaser config to the latest syntax.