### PR TITLE
fix: polling latest submissions

### DIFF
--- a/Autolab/autolab.go
+++ b/Autolab/autolab.go
@@ -73,7 +73,7 @@ func (a Autolab) GetUserAssessments(course string) ([]AssessmentsResponse, error
 
 func (a Autolab) PollLatestSubmission(course, assessment string) (SubmissionsResponse, error) {
 	const timeout = 2 * time.Minute
-	const pollInterval = 5 * time.Second
+	const pollInterval = 10 * time.Second
 	for {
 		select {
 		case <-time.After(timeout):


### PR DESCRIPTION
This fixes #14 and slows down polling--though I'm not sure there was any particular reason to do that, it's just for insurance.

## Summary by Sourcery

Fix the polling mechanism to correctly wait for the next submission version and increase the polling interval to reduce request frequency.

Bug Fixes:
- Fix the polling mechanism to correctly wait for the next submission version before proceeding.

Enhancements:
- Increase the polling interval from 5 seconds to 10 seconds to reduce the frequency of polling requests.